### PR TITLE
logging: Be less verbose

### DIFF
--- a/azafea_metrics_proxy/logging.py
+++ b/azafea_metrics_proxy/logging.py
@@ -66,3 +66,6 @@ def setup_logging(*, verbose: bool = False) -> None:
     if verbose:
         # Decrease verbosity
         logging.getLogger('flake8').setLevel(logging.WARNING)
+
+    else:
+        logging.getLogger('aiohttp.access').setLevel(logging.WARNING)


### PR DESCRIPTION
The aiohttp.access module will log all received HTTP requests at the
INFO level.

This is more output that we care about, especially since we have a
frontal webserver doing that anyway.

Fixes #5