### PR TITLE
Docker modifications to match production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,26 @@
-language: python
+language: minimal
+dist: bionic
 sudo: required
 
 branches:
   only:
   - master
 
-python:
-- "3.7"
-
 services:
-- redis-server
+- docker
 
 install:
-- pipenv install --deploy --dev
-
-before_script:
-# Set the default password for Redis, as that's what the tests expect
-- redis-cli config set requirepass 'CHANGE ME!!'
+- docker build --tag amp .
 
 matrix:
   include:
   - name: "Integration Tests"
+    before_script:
+    - docker run -d --name=redis --network=host redis:5-alpine --requirepass 'CHANGE ME!!'
     script:
-    - pipenv run test-all
+    - docker run --rm --network=host --entrypoint="" amp pipenv run test-all
+    after_script:
+    - docker rm -f redis
   - name: "Lint and Type Checking"
     script:
-    - pipenv run lint
+    - docker run --rm --entrypoint="" amp pipenv run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
     before_script:
     - docker run -d --name=redis --network=host redis:5-alpine --requirepass 'CHANGE ME!!'
     script:
-    - docker run --rm --network=host --entrypoint="" amp pipenv run test-all
+    - docker run --rm --network=host amp test-all
     after_script:
     - docker rm -f redis
   - name: "Lint and Type Checking"
     script:
-    - docker run --rm --entrypoint="" amp pipenv run lint
+    - docker run --rm amp lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-alpine
 
-RUN pip install --no-cache-dir pipenv && \
+RUN pip install --no-cache-dir pipenv template && \
     apk add --update --no-cache git build-base
 
 RUN adduser --system --shell /sbin/nologin --home /opt/azafea-metrics-proxy azafea && \
@@ -14,7 +14,13 @@ RUN pipenv install --ignore-pipfile --dev
 
 COPY . .
 
-ENTRYPOINT ["pipenv", "run", "proxy"]
+ENTRYPOINT ["./entrypoint", "pipenv", "run"]
+
+CMD ["proxy", "-c", "/tmp/config.toml", "run"]
+
+ENV VERBOSE=false
+ENV REDIS_HOST=localhost
+ENV REDIS_PASSWORD="CHANGE ME!!"
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /opt/azafea-metrics-proxy/src
 
 COPY Pipfile.lock .
 
-RUN pipenv install --ignore-pipfile
+RUN pipenv install --ignore-pipfile --dev
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.7-alpine
 RUN pip install --no-cache-dir pipenv && \
     apk add --update --no-cache git build-base
 
+RUN adduser --system --shell /sbin/nologin --home /opt/azafea-metrics-proxy azafea && \
+    install -d -m 755 -o azafea /opt/azafea-metrics-proxy/src
+USER azafea
 WORKDIR /opt/azafea-metrics-proxy/src
 
 COPY Pipfile.lock .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,18 @@
-FROM ubuntu:disco
+FROM python:3.7-alpine
 
-ENV LANG C.UTF-8
+RUN pip install --no-cache-dir pipenv && \
+    apk add --update --no-cache git build-base
 
 WORKDIR /opt/azafea-metrics-proxy/src
 
 COPY Pipfile.lock .
 
-RUN apt --quiet --assume-yes update \
-    && apt --quiet --assume-yes --no-install-recommends install \
-        gcc \
-        python3 \
-        python3-dev \
-        python3-pip \
-    && pip3 install pipenv \
-    && pipenv install --ignore-pipfile \
-    && apt --quiet --assume-yes autoremove --purge \
-        gcc \
-        python3-dev \
-    && rm -rf /var/cache/{apt,debconf} /var/lib/apt/lists/* /var/log/{apt,dpkg.log}
+RUN pipenv install --ignore-pipfile
 
 COPY . .
 
 ENTRYPOINT ["pipenv", "run", "proxy"]
+
+EXPOSE 8080
+
+HEALTHCHECK CMD wget --spider --quiet http://localhost:8080/ --user-agent 'Healthcheck' || exit 1

--- a/azafea_metrics_proxy/tests/test_cli.py
+++ b/azafea_metrics_proxy/tests/test_cli.py
@@ -92,4 +92,3 @@ def test_run_redis_invalid_host(capfd, make_config_file):
 
     capture = capfd.readouterr()
     assert 'Could not connect to Redis:' in capture.err
-    assert 'Name or service not known' in capture.err

--- a/config.toml.j2
+++ b/config.toml.j2
@@ -1,0 +1,6 @@
+[main]
+verbose = {{ VERBOSE }}
+
+[redis]
+host = "{{ REDIS_HOST }}"
+password = "{{ REDIS_PASSWORD }}"

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eux
+
+template config.toml.j2 -o /tmp/config.toml
+eval exec "$@"


### PR DESCRIPTION
This PR is to match the Docker image we build for production use in Endless. Mainly this concerns 2 things, using the Alpine variant of the Python Docker image as the base image and rendering a config file from a template and environment variables in the entrypoint (so we don't have to ship a configuration file along). The CI is changed to use the Docker image (matching what has been done in Azafea). With this we can drop our custom Dockerfile that we use internally in Endless.