### PR TITLE
Fix instructions for running the container

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -79,8 +79,8 @@ Once you built the Docker image and wrote your configuration file, you can
 ensure that the Azafea metrics proxy loads your configuration correctly with
 the following command::
 
-    $ sudo docker run --volume=/etc/azafea-metrics-proxy:/etc/azafea-metrics-proxy:ro proxy print-config
+    $ sudo docker run --volume=/etc/azafea-metrics-proxy:/etc/azafea-metrics-proxy:ro azafea-metrics-proxy proxy print-config
 
 Finally, you can run the Azafea metrics proxy::
 
-    $ sudo docker run --volume=/etc/azafea-metrics-proxy:/etc/azafea-metrics-proxy:ro proxy run
+    $ sudo docker run --volume=/etc/azafea-metrics-proxy:/etc/azafea-metrics-proxy:ro azafea-metrics-proxy proxy run


### PR DESCRIPTION
The instructions create a container named "azafea-metrics-proxy" and then later switch to just "proxy". This needs to be consistent or it won't work.