### PR TITLE
docker: Actually install dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /opt/azafea-metrics-proxy/src
 
 COPY Pipfile.lock .
 
-RUN pipenv install --ignore-pipfile --dev
+RUN pipenv sync --dev
 
 COPY . .
 


### PR DESCRIPTION
Previously, `pipenv install` would relock dependencies unless you
passed `--ignore-pipfile`. This was changed in pipenv 2024.0.0:

> As much requested, the `install` no longer does a complete lock
> operation. Instead `install` follows the same code path as pipenv update
> (which is upgrade + sync).
> – https://github.com/pypa/pipenv/blob/v2024.0.0/CHANGELOG.md#behavior-changes

What does not seem to be documented is that, if no `Pipfile` is present,
`pipenv install` now does nothing.

Adjust for this: add the `Pipfile` to the container as well as
`Pipfile.lock`, and drop `--ignore-pipfile`.