### PR TITLE
dependabot: Group updates for actions/* namespace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # Group updates for actions owned by GitHub into one PR: they often update
+      # them all at once to bump the Node.JS version.
+      github:
+        patterns:
+          - "actions/*"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
It is common for GitHub to release new versions of all their actions in near-lockstep, causing a flood of PRs in each of our projects.